### PR TITLE
Allow disabling LISTEN for notifications

### DIFF
--- a/docs/src/configuration/worker-options.md
+++ b/docs/src/configuration/worker-options.md
@@ -73,6 +73,7 @@ let worker = WorkerOptions::default()
     .schema("my_app_worker")
     .concurrency(10)
     .poll_interval(Duration::from_millis(500))
+    .use_notification_delivery(true)
     .use_local_time(false)
     .pg_pool(pg_pool)
     .define_job::<SendEmail>()
@@ -89,6 +90,9 @@ Important core methods:
   `0` panics.
 - `poll_interval(duration)` controls fallback polling for new or future jobs.
   The default is one second.
+- `use_notification_delivery(value)` controls whether the worker listens for
+  PostgreSQL `NOTIFY` wakeups. The default is `true`; set it to `false` to use
+  polling only.
 - `use_local_time(value)` controls whether timestamps use application time
   (`true`) or PostgreSQL server time (`false`). The default is PostgreSQL server
   time.

--- a/src/builder/core.rs
+++ b/src/builder/core.rs
@@ -60,6 +60,18 @@ impl WorkerOptions {
         self
     }
 
+    /// Sets whether to use PostgreSQL notification delivery.
+    ///
+    /// # Arguments
+    /// * `value` - True to use notification delivery, false to use polling only
+    ///
+    /// # Default
+    /// If not specified, defaults to true
+    pub fn use_notification_delivery(mut self, value: bool) -> Self {
+        self.use_notification_delivery = Some(value);
+        self
+    }
+
     /// Sets whether to use local application time or database time for timestamps.
     ///
     /// When `use_local_time` is true, the application's `Utc::now()` is used for timestamps,

--- a/src/builder/init.rs
+++ b/src/builder/init.rs
@@ -83,6 +83,7 @@ impl WorkerOptions {
 
         let worker_id = format!("graphile_worker_{}", hex::encode(random_bytes));
         let poll_interval = self.poll_interval.unwrap_or(Duration::from_millis(1000));
+        let use_notification_delivery = self.use_notification_delivery.unwrap_or(true);
 
         let hooks = Arc::new(self.hooks);
 
@@ -125,6 +126,7 @@ impl WorkerOptions {
             worker_id,
             concurrency,
             poll_interval,
+            use_notification_delivery,
             jobs: self.jobs,
             database,
             schema,

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -72,6 +72,9 @@ pub struct WorkerOptions {
     /// How often to poll the database for new jobs
     poll_interval: Option<Duration>,
 
+    /// Use notification delivery
+    use_notification_delivery: Option<bool>,
+
     /// Map of job identifiers to handler functions
     jobs: HashMap<String, WorkerFn>,
 

--- a/src/runner/job_loop/direct.rs
+++ b/src/runner/job_loop/direct.rs
@@ -11,6 +11,7 @@ pub(super) async fn run(worker: &Worker) -> Result<(), WorkerRuntimeError> {
     let job_signal = job_signal_stream(
         worker.database.clone(),
         worker.poll_interval,
+        worker.use_notification_delivery,
         worker.shutdown_signal.clone(),
         1,
     )

--- a/src/runner/job_loop/local_queue.rs
+++ b/src/runner/job_loop/local_queue.rs
@@ -17,6 +17,7 @@ pub(super) async fn run(
     let job_signal = job_signal_stream_with_receiver(
         worker.database.clone(),
         worker.poll_interval,
+        worker.use_notification_delivery,
         worker.shutdown_signal.clone(),
         1,
         job_signal_rx,

--- a/src/runner/lifecycle/mod.rs
+++ b/src/runner/lifecycle/mod.rs
@@ -71,6 +71,7 @@ impl Worker {
             worker_id: self.worker_id.clone(),
             concurrency: self.concurrency,
             poll_interval: self.poll_interval,
+            use_notification_delivery: self.use_notification_delivery,
             jobs: self.jobs.clone(),
             database: self.database.clone(),
             schema: self.schema.clone(),

--- a/src/runner/types.rs
+++ b/src/runner/types.rs
@@ -38,6 +38,8 @@ pub struct Worker {
     pub(crate) concurrency: usize,
     /// How often to poll for new jobs when no notifications are received
     pub(crate) poll_interval: Duration,
+    /// Whether to LISTEN to job notifications
+    pub(crate) use_notification_delivery: bool,
     /// Map of task identifiers to their handler functions
     pub(crate) jobs: HashMap<String, WorkerFn>,
     /// Database connection pool

--- a/src/streams/job_signal/mod.rs
+++ b/src/streams/job_signal/mod.rs
@@ -49,10 +49,19 @@ pub type JobSignalReceiver = runtime::Receiver<()>;
 pub async fn job_signal_stream(
     database: Database,
     poll_interval: Duration,
+    use_notification_system: bool,
     shutdown_signal: ShutdownSignal,
     concurrency: usize,
 ) -> Result<impl Stream<Item = StreamSource>> {
-    job_signal_stream_internal(database, poll_interval, shutdown_signal, concurrency, None).await
+    job_signal_stream_internal(
+        database,
+        poll_interval,
+        use_notification_system,
+        shutdown_signal,
+        concurrency,
+        None,
+    )
+    .await
 }
 
 /// Creates a stream that yields job processing signals, with a provided receiver for internal signaling.
@@ -62,6 +71,7 @@ pub async fn job_signal_stream(
 pub async fn job_signal_stream_with_receiver(
     database: Database,
     poll_interval: Duration,
+    use_notification_system: bool,
     shutdown_signal: ShutdownSignal,
     concurrency: usize,
     internal_rx: JobSignalReceiver,
@@ -69,6 +79,7 @@ pub async fn job_signal_stream_with_receiver(
     job_signal_stream_internal(
         database,
         poll_interval,
+        use_notification_system,
         shutdown_signal,
         concurrency,
         Some(internal_rx),
@@ -79,12 +90,19 @@ pub async fn job_signal_stream_with_receiver(
 async fn job_signal_stream_internal(
     database: Database,
     poll_interval: Duration,
+    use_notification_system: bool,
     shutdown_signal: ShutdownSignal,
     concurrency: usize,
     internal_rx: Option<runtime::Receiver<()>>,
 ) -> Result<impl Stream<Item = StreamSource>> {
     let interval = runtime::interval(poll_interval);
-    let pg_listener = database.listen("jobs:insert").await?;
+
+    let pg_listener = if use_notification_system {
+        database.listen("jobs:insert").await?
+    } else {
+        None
+    };
+
     let stream_data = JobSignalStreamData::new(
         interval,
         pg_listener,

--- a/src/streams/job_signal/mod.rs
+++ b/src/streams/job_signal/mod.rs
@@ -40,7 +40,8 @@ pub type JobSignalReceiver = runtime::Receiver<()>;
 /// This function returns a stream that emits signals when the worker should check for jobs.
 /// The signals come from:
 /// 1. Regular interval-based polling (every `poll_interval`)
-/// 2. PostgreSQL notifications when new jobs are inserted (`NOTIFY 'jobs:insert'`)
+/// 2. PostgreSQL notifications when notification delivery is enabled and new jobs are inserted
+///    (`NOTIFY 'jobs:insert'`)
 ///
 /// When a signal is received, the stream will emit enough items to utilize the
 /// configured concurrency (one item per potential concurrent job).

--- a/tests/builder/database_url.rs
+++ b/tests/builder/database_url.rs
@@ -12,6 +12,7 @@ async fn worker_options_initializes_from_database_url() {
             .with_cron(Cron::every_minute::<BuilderJob>())
             .with_cron("* * * * * builder_job")
             .expect("Failed to add second crontab")
+            .use_notification_delivery(false)
             .use_local_time(true)
             .on(JobStart, |_ctx| async {})
             .define_job::<BuilderJob>()
@@ -20,6 +21,7 @@ async fn worker_options_initializes_from_database_url() {
             .expect("Failed to create worker");
 
         assert!(*worker.use_local_time());
+        assert!(!*worker.use_notification_delivery());
         assert_eq!(worker.crontabs().len(), 2);
         assert_eq!(worker.concurrency(), &num_cpus::get());
     })

--- a/tests/job_signal_stream.rs
+++ b/tests/job_signal_stream.rs
@@ -1,0 +1,109 @@
+use std::any::Any;
+use std::fmt;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+use std::time::Duration;
+
+use futures::{FutureExt, StreamExt};
+use graphile_worker::{
+    streams::{job_signal_stream, StreamSource},
+    BoxFuture, Database, DatabaseDriver, DbError, DbExecutor, DbParams, DbRow, DbTransaction,
+    NotificationStream, ShutdownSignal,
+};
+
+#[derive(Clone, Default)]
+struct ListenCountingDriver {
+    listen_calls: Arc<AtomicUsize>,
+}
+
+impl ListenCountingDriver {
+    fn listen_calls(&self) -> usize {
+        self.listen_calls.load(Ordering::SeqCst)
+    }
+}
+
+impl fmt::Debug for ListenCountingDriver {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ListenCountingDriver").finish()
+    }
+}
+
+impl DbExecutor for ListenCountingDriver {
+    fn execute<'a>(
+        &'a self,
+        _sql: &'a str,
+        _params: DbParams,
+    ) -> BoxFuture<'a, Result<u64, DbError>> {
+        Box::pin(async { Ok(0) })
+    }
+
+    fn fetch_all<'a>(
+        &'a self,
+        _sql: &'a str,
+        _params: DbParams,
+    ) -> BoxFuture<'a, Result<Vec<DbRow>, DbError>> {
+        Box::pin(async { Ok(Vec::new()) })
+    }
+}
+
+impl DatabaseDriver for ListenCountingDriver {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn begin<'a>(&'a self) -> BoxFuture<'a, Result<DbTransaction, DbError>> {
+        Box::pin(async { Err(DbError::new("transactions are unavailable")) })
+    }
+
+    fn listen<'a>(
+        &'a self,
+        _channel: &'a str,
+    ) -> BoxFuture<'a, Result<Option<NotificationStream>, DbError>> {
+        self.listen_calls.fetch_add(1, Ordering::SeqCst);
+        Box::pin(async { Err(DbError::new("listen should not be called")) })
+    }
+}
+
+fn pending_shutdown_signal() -> ShutdownSignal {
+    futures::future::pending::<()>().boxed().shared()
+}
+
+#[tokio::test]
+async fn disabled_notification_delivery_skips_listener() {
+    let driver = ListenCountingDriver::default();
+    let database = Database::new(driver.clone());
+
+    let stream = job_signal_stream(
+        database,
+        Duration::from_millis(1),
+        false,
+        pending_shutdown_signal(),
+        1,
+    )
+    .await
+    .expect("stream should initialize");
+
+    futures::pin_mut!(stream);
+    assert_eq!(stream.next().await, Some(StreamSource::Polling));
+    assert_eq!(driver.listen_calls(), 0);
+}
+
+#[tokio::test]
+async fn enabled_notification_delivery_opens_listener() {
+    let driver = ListenCountingDriver::default();
+    let database = Database::new(driver.clone());
+
+    let result = job_signal_stream(
+        database,
+        Duration::from_millis(1),
+        true,
+        pending_shutdown_signal(),
+        1,
+    )
+    .await;
+
+    assert!(result.is_err());
+    assert_eq!(driver.listen_calls(), 1);
+}


### PR DESCRIPTION
This PR allows disabling "notification delivery" (LISTEN jobs:insert).

I attempted to reproduce the problem locally, but couldn't. But it appears in our production rather reliably.

`LISTEN "jobs:insert"` gets stuck in `ClientWrite` event with `backend_xmin` set, which creates "xmin horizon", and prevents autovacuum from doing its job. With restart it goes away for few hours, but then come backs.

```
> select wait_event, backend_xmin, query from pg_stat_activity where query like 'LISTEN %';
 wait_event  | backend_xmin |        query
-------------+--------------+----------------------
 ClientWrite |              | LISTEN "jobs:insert"
 ClientWrite |    113623478 | LISTEN "jobs:insert"
 ClientWrite |    113623478 | LISTEN "jobs:insert"
 ClientWrite |    113623478 | LISTEN "jobs:insert"
 ClientWrite |    113423576 | LISTEN "jobs:insert"
 ClientRead  |              | LISTEN "jobs:insert"
 ClientWrite |    113623478 | LISTEN "jobs:insert"
 ClientWrite |    113623478 | LISTEN "jobs:insert"
 ClientWrite |    113527349 | LISTEN "jobs:insert"
 ClientWrite |    113623478 | LISTEN "jobs:insert"
(10 rows)
```

Jobs are one of the affected tables due to this, because it needs vacuuming to work properly. Here's an example when I had to restart all workers:

<img width="1056" height="453" alt="image" src="https://github.com/user-attachments/assets/7727a211-b7da-4e9c-b51e-9c147fda8634" />

While this is not ideal, not doing `LISTEN` would resolve this issue, and it appears there's already code to do polling without `LISTEN`.

At the moment we're running version `0.13.2`, but I have observed this issue with c29323b5c79c9ee5bac07bb9fa8cbead03f619a1 (used this ref for sqlx 0.9). I'm not sure if the problem occurred with sqlx 0.8.