### PR TITLE
fix: use SPDX license = "MIT" instead of license-file

### DIFF
--- a/crates/graphile-worker-crontab-parser/Cargo.toml
+++ b/crates/graphile-worker-crontab-parser/Cargo.toml
@@ -2,7 +2,7 @@
 name = "graphile_worker_crontab_parser"
 version = "0.5.23"
 edition = "2021"
-license-file = "LICENSE.md"
+license = "MIT"
 description = "Crontab parsing package for graphile_worker, a high performance Rust/PostgreSQL job queue"
 homepage = "https://docs.rs/graphile_worker_crontab_parser"
 documentation = "https://docs.rs/graphile_worker_crontab_parser"

--- a/crates/graphile-worker-crontab-runner/Cargo.toml
+++ b/crates/graphile-worker-crontab-runner/Cargo.toml
@@ -2,7 +2,7 @@
 name = "graphile_worker_crontab_runner"
 version = "0.7.9"
 edition = "2021"
-license-file = "LICENSE.md"
+license = "MIT"
 description = "Crontab runner package for graphile worker, a high performance Rust/PostgreSQL job queue"
 homepage = "https://docs.rs/graphile_worker_crontab_runner"
 documentation = "https://docs.rs/graphile_worker_crontab_runner"

--- a/crates/graphile-worker-crontab-types/Cargo.toml
+++ b/crates/graphile-worker-crontab-types/Cargo.toml
@@ -2,7 +2,7 @@
 name = "graphile_worker_crontab_types"
 version = "0.5.17"
 edition = "2021"
-license-file = "LICENSE.md"
+license = "MIT"
 description = "Crontab types package for graphile_worker, a high performance Rust/PostgreSQL job queue"
 homepage = "https://docs.rs/graphile_worker_crontab_types"
 documentation = "https://docs.rs/graphile_worker_crontab_types"

--- a/crates/graphile-worker-ctx/Cargo.toml
+++ b/crates/graphile-worker-ctx/Cargo.toml
@@ -2,7 +2,7 @@
 name = "graphile_worker_ctx"
 version = "0.6.1"
 edition = "2021"
-license-file = "LICENSE.md"
+license = "MIT"
 description = "Worker Context package for graphile_worker, a high performance Rust/PostgreSQL job queue"
 homepage = "https://docs.rs/graphile_worker_crontab_types"
 documentation = "https://docs.rs/graphile_worker_crontab_types"

--- a/crates/graphile-worker-extensions/Cargo.toml
+++ b/crates/graphile-worker-extensions/Cargo.toml
@@ -2,7 +2,7 @@
 name = "graphile_worker_extensions"
 version = "0.1.8"
 edition = "2021"
-license-file = "LICENSE.md"
+license = "MIT"
 description = "Extensions package for graphile_worker, a high performance Rust/PostgreSQL job queue"
 homepage = "https://docs.rs/graphile_worker_crontab_types"
 documentation = "https://docs.rs/graphile_worker_crontab_types"

--- a/crates/graphile-worker-job-spec/Cargo.toml
+++ b/crates/graphile-worker-job-spec/Cargo.toml
@@ -2,7 +2,7 @@
 name = "graphile_worker_job_spec"
 version = "0.1.5"
 edition = "2021"
-license-file = "LICENSE.md"
+license = "MIT"
 description = "Job specification types for graphile_worker, a high performance Rust/PostgreSQL job queue"
 homepage = "https://docs.rs/graphile_worker"
 documentation = "https://docs.rs/graphile_worker"

--- a/crates/graphile-worker-job/Cargo.toml
+++ b/crates/graphile-worker-job/Cargo.toml
@@ -2,7 +2,7 @@
 name = "graphile_worker_job"
 version = "0.2.1"
 edition = "2021"
-license-file = "LICENSE.md"
+license = "MIT"
 description = "Job package for graphile_worker, a high performance Rust/PostgreSQL job queue"
 homepage = "https://docs.rs/graphile_worker_job"
 documentation = "https://docs.rs/graphile_worker_job"

--- a/crates/graphile-worker-lifecycle-hooks/Cargo.toml
+++ b/crates/graphile-worker-lifecycle-hooks/Cargo.toml
@@ -2,7 +2,7 @@
 name = "graphile_worker_lifecycle_hooks"
 version = "0.3.4"
 edition = "2021"
-license-file = "LICENSE.md"
+license = "MIT"
 description = "Lifecycle hooks for graphile_worker, a high performance Rust/PostgreSQL job queue"
 homepage = "https://docs.rs/graphile_worker"
 documentation = "https://docs.rs/graphile_worker"

--- a/crates/graphile-worker-migrations-core/Cargo.toml
+++ b/crates/graphile-worker-migrations-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "graphile_worker_migrations_core"
 version = "0.1.0"
 edition = "2021"
-license-file = "LICENSE.md"
+license = "MIT"
 description = "Core migration types for graphile_worker_migrations"
 homepage = "https://docs.rs/graphile_worker_migrations"
 documentation = "https://docs.rs/graphile_worker_migrations"

--- a/crates/graphile-worker-migrations-macros/Cargo.toml
+++ b/crates/graphile-worker-migrations-macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "graphile_worker_migrations_macros"
 version = "0.1.1"
 edition = "2021"
-license-file = "LICENSE.md"
+license = "MIT"
 description = "Proc macros for graphile_worker_migrations"
 homepage = "https://docs.rs/graphile_worker_migrations"
 documentation = "https://docs.rs/graphile_worker_migrations"

--- a/crates/graphile-worker-migrations/Cargo.toml
+++ b/crates/graphile-worker-migrations/Cargo.toml
@@ -2,7 +2,7 @@
 name = "graphile_worker_migrations"
 version = "0.4.20"
 edition = "2021"
-license-file = "LICENSE.md"
+license = "MIT"
 description = "Migrations package for graphile_worker, a high performance Rust/PostgreSQL job queue"
 homepage = "https://docs.rs/graphile_worker_migrations"
 documentation = "https://docs.rs/graphile_worker_migrations"

--- a/crates/graphile-worker-runtime/Cargo.toml
+++ b/crates/graphile-worker-runtime/Cargo.toml
@@ -2,7 +2,7 @@
 name = "graphile_worker_runtime"
 version = "0.1.3"
 edition = "2021"
-license-file = "LICENSE.md"
+license = "MIT"
 description = "Async runtime compatibility package for graphile_worker"
 homepage = "https://docs.rs/graphile_worker_runtime"
 documentation = "https://docs.rs/graphile_worker_runtime"

--- a/crates/graphile-worker-shutdown-signal/Cargo.toml
+++ b/crates/graphile-worker-shutdown-signal/Cargo.toml
@@ -2,7 +2,7 @@
 name = "graphile_worker_shutdown_signal"
 version = "0.3.13"
 edition = "2021"
-license-file = "LICENSE.md"
+license = "MIT"
 description = "Migrations package for graphile_worker, a high performance Rust/PostgreSQL job queue"
 homepage = "https://docs.rs/graphile_worker_shutdown_signal"
 documentation = "https://docs.rs/graphile_worker_shutdown_signal"

--- a/crates/graphile-worker-task-details/Cargo.toml
+++ b/crates/graphile-worker-task-details/Cargo.toml
@@ -2,7 +2,7 @@
 name = "graphile_worker_task_details"
 version = "0.1.5"
 edition = "2021"
-license-file = "LICENSE.md"
+license = "MIT"
 description = "Task details for graphile_worker, mapping task IDs to identifiers"
 homepage = "https://docs.rs/graphile_worker"
 documentation = "https://docs.rs/graphile_worker"

--- a/crates/graphile-worker-task-handler/Cargo.toml
+++ b/crates/graphile-worker-task-handler/Cargo.toml
@@ -2,7 +2,7 @@
 name = "graphile_worker_task_handler"
 version = "0.5.19"
 edition = "2021"
-license-file = "LICENSE.md"
+license = "MIT"
 description = "A library to handle tasks for the Graphile Worker project"
 homepage = "https://docs.rs/graphile_worker_task_handler"
 documentation = "https://docs.rs/graphile_worker_task_handler"


### PR DESCRIPTION
These crates set only license-file = "LICENSE.md", leaving the SPDX license field empty. Tools that read package metadata (cargo-deny, docs.rs, license and SBOM scanners) key off the license field, so they warn about the missing field or fall back to text-detecting the LICENSE file. Declaring license = "MIT" makes the license machine-readable and consistent with the other workspace crates and the root package.